### PR TITLE
config_example中添加deck.url 

### DIFF
--- a/example_config/sekai/sekai.yaml
+++ b/example_config/sekai/sekai.yaml
@@ -34,6 +34,7 @@ story_summary:
 
 
 deck:
+  url: "http://localhost:45556/recommend"
   default_algs: ['dfs', 'ga']
   timeout:
     default: 5


### PR DESCRIPTION
sekai/modules/deck.py的url改成了从config获取，但是没有在config_example中添加