### PR TITLE
Replace playwright with selenium

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,6 @@ bypy
 colour-science
 opencv-python
 zstandard
-selenium
 google-genai
 aiosqlite
 rapidfuzz

--- a/src/plugins/bird/__init__.py
+++ b/src/plugins/bird/__init__.py
@@ -34,13 +34,14 @@ async def get_wiki_page_image(ctx: HandlerContext, name: str, url: str, refresh:
         return sorted(files)
     try:
         await ctx.asend_reply_msg(f"正在获取{name}的wiki页面...")
-        async with WebDriver() as driver:
-            driver.get(url)
-            WebDriverWait(driver, 10).until(
-                lambda d: d.execute_script('return document.readyState') == 'complete'
+        async with PlaywrightPage() as page:
+            await page.goto(url, wait_until='networkidle')
+            pdf = await page.pdf(
+                format='A4', # 设置页面格式
+                print_background=True, # 确保背景打印
+                margin={"top": "0.5in", "bottom": "0.5in", "left": "0.5in", "right": "0.5in"} # 边距设置
             )
-            pdf = driver.print_page()
-        pdf = base64.b64decode(pdf)
+        # page.pdf本身返回的就是bytes
         with TempFilePath("pdf") as pdf_path:
             with open(pdf_path, 'wb') as f:
                 f.write(pdf)

--- a/src/plugins/imgexp/__init__.py
+++ b/src/plugins/imgexp/__init__.py
@@ -117,21 +117,23 @@ async def _(ctx: HandlerContext):
 
 
 async def get_twitter_image_urls(url):
-    async with WebDriver() as driver:
+    async with PlaywrightPage() as page: # 获取 Playwright Page
         @retry(wait=wait_fixed(1), stop=stop_after_attempt(3), reraise=True)
-        def get_image_urls(url):
-            import bs4
-            driver.get(url)
-            time.sleep(3)
-            soup = bs4.BeautifulSoup(driver.page_source, features="lxml")
-            with open('sandbox/test.html', 'w') as f:
-                f.write(soup.prettify())
-            images = soup.find_all('img')
-            images = [img['src'] for img in images if '/media/' in img['src']]
-            images = [image[:image.rfind('&')] + "&name=large" for image in images]
-            return images
-        return await run_in_pool(get_image_urls, url)
-
+        async def get_image_urls(url): # 访问连接，读取内容，因为playwright是异步的所以用异步方法
+            await page.goto(url, wait_until='networkidle')
+            await asyncio.sleep(3) 
+            html_content = await page.content()
+            def _parse_and_extract_image_urls(html_content: str) -> list[str]: # 因为BeautifulSoup是同步的，将它放入线程池中运行
+                import bs4
+                soup = bs4.BeautifulSoup(html_content, features="lxml")
+                with open('sandbox/test.html', 'w') as f:
+                    f.write(soup.prettify())
+                images = soup.find_all('img')
+                images = [img['src'] for img in images if '/media/' in img['src']]
+                images = [image[:image.rfind('&')] + "&name=large" for image in images]
+                return images
+            return await run_in_pool(_parse_and_extract_image_urls, html_content)
+        return await get_image_urls(url)
 
 ximg = CmdHandler(['/ximg', '/x_img', '/twimg', '/tw_img'], logger)
 ximg.check_cdrate(cd).check_wblist(gbl, allow_private=True)


### PR DESCRIPTION
既然已经有了playwright，那就不需要selenium了，它自带异步调用可以当作selenium的上位替代。
于是我用Playwright换掉了原本的selenium，这样可以直接把selenium删掉，也不用下载两种浏览器驱动了。
虽然我自己做过测试，用起来一样，但不能保证它完全没问题。老大有空可以看看，无视它也没有关系。
修改的地方：
requirements.txt:  
    - 删掉了selenium
src/plugins/utils/utils.py:  
    - 删掉了WebDriver类，改为PlaywrightPage类。它使用playwright的异步api，上下文管理器返回的Playwright的Page对象。
    - 修改download_and_convert_svg和markdown_to_image函数，让它们使用PlaywrightPage来替换原本的WebDriver。
src/plugins/imgexp/__init__.py:
    - 修改get_twitter_image_urls函数，不过没有进行测试。
src/plugins/bird/__init__.py:
    - 修改get_wiki_page_image函数，使用PlaywrightPage来替换原本的WebDriver。