### PR TITLE
Refactor extract_nickname_from_args for better matching

### DIFF
--- a/src/plugins/sekai/common.py
+++ b/src/plugins/sekai/common.py
@@ -243,12 +243,17 @@ def get_cid_by_nickname(nickname: str) -> Optional[int]:
 
 # 从参数中提取角色昵称，返回角色ID和剩余参数
 def extract_nickname_from_args(args: str, default=None) -> Tuple[Optional[str], str]:
+    best_match: str | None = default # 最匹配的一项，也就是匹配的长度最长的一项
+    max_length: int = 0 # 最匹配的一项的长度
     for item in get_character_nickname_data():
         for nickname in item.nicknames:
             if nickname in args:
-                args = args.replace(nickname, "").strip()
-                return nickname, args
-    return default, args
+                current_length = len(nickname)
+                if current_length > max_length:
+                    best_match = nickname
+    if best_match is not None:
+        args = args.replace(best_match, "").strip()
+    return best_match, args
 
 # 获取所有(昵称, 角色ID)对
 def get_all_nickname_cid_pairs() -> List[Tuple[str, int]]:


### PR DESCRIPTION
之前是找到一项就返回，导致从“真冬”或“朝比奈真冬”中找到“冬”就直接返回了。
现在改成查找所有的昵称，然后从中返回最长的一项。