### PR TITLE
[fix] 修复查询单个排名时，获取排名异常的错误

### DIFF
--- a/src/plugins/sekai/modules/sk.py
+++ b/src/plugins/sekai/modules/sk.py
@@ -556,8 +556,8 @@ async def get_sk_query_params(ctx: SekaiHandlerContext, args: str) -> Tuple[str,
             assert_and_reply(end in ALL_RANKS, f"不支持的结束排名: {end}")
             return 'ranks', list(range(start, end + 1))
         elif is_rank_text(args):
-            if is_rank_text(args) in ALL_RANKS:
-                return 'rank', is_rank_text(args)
+            if (rank:=get_rank_from_text(args)) in ALL_RANKS:
+                return 'rank', rank
             else:
                 return 'uid', int(args)
     raise ReplyException(f"""


### PR DESCRIPTION
查询单个排名时总会返回排名第一的结果，因为这里返回了True