### PR TITLE
[update] 在调用get_detailed_profile时设置filter

### DIFF
--- a/src/plugins/sekai/modules/card.py
+++ b/src/plugins/sekai/modules/card.py
@@ -7,6 +7,7 @@ from ..draw import *
 from .profile import (
     get_detailed_profile, 
     get_detailed_profile_card, 
+    get_detailed_profile_card_filter,
     get_player_avatar_info_by_detailed_profile,
     has_after_training,
     only_has_after_training,
@@ -237,7 +238,7 @@ async def get_cards_of_event(ctx: SekaiHandlerContext, event_id: int) -> List[di
 # 合成卡牌列表图片
 async def compose_card_list_image(ctx: SekaiHandlerContext, cards: List[Dict], qid: int):
     if qid:
-        profile, pmsg = await get_detailed_profile(ctx, qid, raise_exc=True)
+        profile, pmsg = await get_detailed_profile(ctx, qid, filter=get_detailed_profile_card_filter('userCards'), raise_exc=True)
         if profile:
             box_card_ids = set([uc['cardId'] for uc in profile['userCards']])
             cards = [c for c in cards if c['id'] in box_card_ids]
@@ -486,7 +487,7 @@ async def get_card_story_summary(ctx: SekaiHandlerContext, card: dict, refresh: 
 async def compose_box_image(ctx: SekaiHandlerContext, qid: int, cards: dict, show_id: bool, show_box: bool, use_after_training=True):
     pcards, bg_unit = [], None
     if qid:
-        profile, pmsg = await get_detailed_profile(ctx, qid, raise_exc=show_box)
+        profile, pmsg = await get_detailed_profile(ctx, qid, filter=get_detailed_profile_card_filter('userCards'), raise_exc=show_box)
         if profile:
             pcards = profile['userCards']
             avatar_info = await get_player_avatar_info_by_detailed_profile(ctx, profile)

--- a/src/plugins/sekai/modules/deck.py
+++ b/src/plugins/sekai/modules/deck.py
@@ -10,6 +10,7 @@ from .profile import (
     get_basic_profile,
     get_detailed_profile, 
     get_detailed_profile_card, 
+    get_detailed_profile_card_filter,
     get_card_full_thumbnail,
 )
 from .education import get_user_challenge_live_info
@@ -1314,7 +1315,24 @@ async def compose_deck_recommend_image(
     else:
         # 用户信息
         with Timer("deckrec:get_detailed_profile", logger):
-            profile, pmsg = await get_detailed_profile(ctx, qid, raise_exc=True, ignore_hide=True)
+            profile, pmsg = await get_detailed_profile(
+                ctx, 
+                qid, 
+                filter=get_detailed_profile_card_filter(
+                    'userGamedata',
+                    'userDecks',
+                    'userCards',
+                    'userHonors',
+                    "userMysekaiCanvases",
+                    "userCharacters",
+                    "userMysekaiGates",
+                    "userMysekaiFixtureGameCharacterPerformanceBonuses",
+                    "userAreas", 
+                    'userChallengeLiveSoloDecks',
+                    'userChallengeLiveSoloHighScoreRewards',
+                    'userChallengeLiveSoloStages',
+                    'userChallengeLiveSoloResults'),
+                raise_exc=True, ignore_hide=True)
             uid = profile['userGamedata']['userId']
 
     original_usercards = profile['userCards']

--- a/src/plugins/sekai/modules/education.py
+++ b/src/plugins/sekai/modules/education.py
@@ -7,6 +7,7 @@ from .resbox import get_res_box_info, get_res_icon
 from .profile import (
     get_detailed_profile,
     get_detailed_profile_card,
+    get_detailed_profile_card_filter,
     get_player_avatar_info_by_detailed_profile,
 )
 
@@ -58,8 +59,11 @@ async def get_user_challenge_live_info(ctx: SekaiHandlerContext, profile: dict) 
 
 # 合成挑战live详情图片
 async def compose_challenge_live_detail_image(ctx: SekaiHandlerContext, qid: int) -> Image.Image:
-    profile, err_msg = await get_detailed_profile(ctx, qid, raise_exc=True)
-
+    profile, err_msg = await get_detailed_profile(
+        ctx, qid, 
+        filter=get_detailed_profile_card_filter('userChallengeLiveSoloResults','userChallengeLiveSoloStages','userChallengeLiveSoloHighScoreRewards'), 
+        raise_exc=True)
+    
     challenge_info = await get_user_challenge_live_info(ctx, profile)
 
     header_h, row_h = 56, 48
@@ -194,8 +198,12 @@ async def get_user_power_bonus(ctx: SekaiHandlerContext, profile: dict) -> Dict[
 
 # 合成加成详情图片
 async def compose_power_bonus_detail_image(ctx: SekaiHandlerContext, qid: int) -> Image.Image:
-    profile, err_msg = await get_detailed_profile(ctx, qid, raise_exc=True)
-
+    profile, err_msg = await get_detailed_profile(
+        ctx, 
+        qid, 
+        filter=get_detailed_profile_card_filter('userAreas','userCharacters','userMysekaiFixtureGameCharacterPerformanceBonuses','userMysekaiGates'), 
+        raise_exc=True)
+ 
     bonus = await get_user_power_bonus(ctx, profile)
     chara_bonus = bonus['chara']
     unit_bonus = bonus['unit']
@@ -245,8 +253,13 @@ async def compose_power_bonus_detail_image(ctx: SekaiHandlerContext, qid: int) -
 async def compose_area_item_upgrade_materials_image(ctx: SekaiHandlerContext, qid: int, filter: AreaItemFilter) -> Image.Image:
     profile = None
     if qid:
-        profile, pmsg = await get_detailed_profile(ctx, qid, raise_exc=True, ignore_hide=True)
-
+        profile, pmsg = await get_detailed_profile(
+            ctx, 
+            qid, 
+            filter=get_detailed_profile_card_filter('userMaterials','userGamedata','userAreas',),
+            raise_exc=True, 
+            ignore_hide=True)
+        
     COIN_ID = -1
     user_materials: dict[int, int] = {}
     user_area_item_lvs: dict[int, int] = {}
@@ -444,8 +457,12 @@ async def compose_area_item_upgrade_materials_image(ctx: SekaiHandlerContext, qi
 
 # 合成羁绊等级图片
 async def compose_bonds_image(ctx: SekaiHandlerContext, qid: int, cid: int | None) -> Image.Image:
-    profile, err_msg = await get_detailed_profile(ctx, qid, raise_exc=True)
-
+    profile, err_msg = await get_detailed_profile(
+        ctx, 
+        qid, 
+        filter=get_detailed_profile_card_filter('userBonds'),
+        raise_exc=True)
+    
     user_bonds = profile.get('userBonds')
     assert_and_reply(user_bonds, "你的Suite数据来源没有提供userBonds数据")
 
@@ -566,7 +583,11 @@ async def compose_bonds_image(ctx: SekaiHandlerContext, qid: int, cid: int | Non
 
 # 合成队长次数图片
 async def compose_leader_count_image(ctx: SekaiHandlerContext, qid: int) -> Image.Image:
-    profile, err_msg = await get_detailed_profile(ctx, qid, raise_exc=True)
+    profile, err_msg = await get_detailed_profile(
+        ctx, 
+        qid, 
+        filter=get_detailed_profile_card_filter('userCharacterMissionV2s', 'userCharacterMissionV2Statuses'),
+        raise_exc=True)
 
     ucms = profile.get('userCharacterMissionV2s')
     ucm_ss = profile.get('userCharacterMissionV2Statuses')

--- a/src/plugins/sekai/modules/event.py
+++ b/src/plugins/sekai/modules/event.py
@@ -10,6 +10,7 @@ from .profile import (
     get_player_bind_id,
     get_detailed_profile,
     get_detailed_profile_card,
+    get_detailed_profile_card_filter,
     get_player_avatar_info_by_detailed_profile,
     request_gameapi,
 )
@@ -838,7 +839,11 @@ async def compose_event_detail_image(ctx: SekaiHandlerContext, event: dict) -> I
 
 # 合成活动记录图片
 async def compose_event_record_image(ctx: SekaiHandlerContext, qid: int) -> Image.Image:
-    profile, err_msg = await get_detailed_profile(ctx, qid, raise_exc=True)
+    profile, err_msg = await get_detailed_profile(
+        ctx, 
+        qid, 
+        filter=get_detailed_profile_card_filter('userEvents','userWorldBlooms'), 
+        raise_exc=True)
     user_events: List[Dict[str, Any]] = profile.get('userEvents', [])
     user_worldblooms: List[Dict[str, Any]] = profile.get('userWorldBlooms', [])
     for item in user_worldblooms:

--- a/src/plugins/sekai/modules/music.py
+++ b/src/plugins/sekai/modules/music.py
@@ -8,6 +8,7 @@ from ..sub import SekaiUserSubHelper, SekaiGroupSubHelper
 from .profile import (
     get_detailed_profile, 
     get_detailed_profile_card, 
+    get_detailed_profile_card_filter,
     get_player_avatar_info_by_detailed_profile,
     get_player_avatar_info_by_basic_profile,
     get_basic_profile,
@@ -980,7 +981,11 @@ async def compose_music_list_image(
         for m, cover in zip(musics, covers):
             m['cover_img'] = cover
         
-    profile, err_msg = await get_detailed_profile(ctx, qid, raise_exc=play_result_filter is not None)
+    profile, err_msg = await get_detailed_profile(
+        ctx, 
+        qid, 
+        filter=get_detailed_profile_card_filter('userMusicResults'),
+        raise_exc=play_result_filter is not None)
     bg_unit = (await get_player_avatar_info_by_detailed_profile(ctx, profile)).unit if profile else None
 
     if play_result_filter is None:
@@ -1050,7 +1055,11 @@ async def compose_music_list_image(
 
 # 合成打歌进度图片
 async def compose_play_progress_image(ctx: SekaiHandlerContext, diff: str, qid: int) -> Image.Image:
-    profile, err_msg = await get_detailed_profile(ctx, qid, raise_exc=True)
+    profile, err_msg = await get_detailed_profile(
+        ctx, 
+        qid, 
+        filter=get_detailed_profile_card_filter('userMusicResults'),
+        raise_exc=True)
     bg_unit = (await get_player_avatar_info_by_detailed_profile(ctx, profile)).unit
 
     count = { lv: PlayProgressCount() for lv in range(1, 40) }
@@ -1258,7 +1267,11 @@ async def compose_music_brief_list_image(
 
 # 合成歌曲奖励图片
 async def compose_music_rewards_image(ctx: SekaiHandlerContext, qid: int) -> Image.Image:
-    profile, err_msg = await get_detailed_profile(ctx, qid, raise_exc=False)
+    profile, err_msg = await get_detailed_profile(
+        ctx, 
+        qid, 
+        filter=get_detailed_profile_card_filter('userMusicAchievements'),
+        raise_exc=False)
     # 获取有效歌曲id
     mids = [m['id'] for m in await get_valid_musics(ctx, leak=False)]
 

--- a/src/plugins/sekai/modules/mysekai.py
+++ b/src/plugins/sekai/modules/mysekai.py
@@ -17,6 +17,7 @@ from .profile import (
     get_user_data_mode,
     get_detailed_profile,
     get_detailed_profile_card,
+    get_detailed_profile_card_filter,
     process_hide_uid,
     get_player_frames,
     get_avatar_widget_with_frame,
@@ -1385,7 +1386,11 @@ async def compose_mysekai_door_upgrade_image(ctx: SekaiHandlerContext, qid: int,
 
     profile = None
     if qid:
-        profile, pmsg = await get_detailed_profile(ctx, qid, raise_exc=True, ignore_hide=True)
+        profile, pmsg = await get_detailed_profile(
+            ctx, 
+            qid, 
+            filter=get_detailed_profile_card_filter('userMysekaiMaterials','userMysekaiGates'),
+            raise_exc=True, ignore_hide=True)
 
     # 获取玩家的材料
     user_materials = {}
@@ -1681,7 +1686,11 @@ async def compose_mysekai_talk_list_image(
         chara_icon = await get_character_sd_image(cuid)
 
         if not show_all_talks:
-            profile, pmsg = await get_detailed_profile(ctx, qid, raise_exc=True)
+            profile, pmsg = await get_detailed_profile(
+                ctx, 
+                qid, 
+                filter=get_detailed_profile_card_filter('userMysekaiCharacterTalks'),
+                raise_exc=True)
             assert_and_reply('userMysekaiCharacterTalks' in profile, "你的Suite抓包数据来源没有提供角色家具对话数据")
             user_character_talks = profile['userMysekaiCharacterTalks']
         else:

--- a/src/plugins/sekai/modules/profile.py
+++ b/src/plugins/sekai/modules/profile.py
@@ -622,7 +622,7 @@ async def get_detailed_profile(
     raise_exc=False, 
     mode=None, 
     ignore_hide=False, 
-    filter: list[str]=None,
+    filter: list[str] | set[str] | None=None,
 ) -> Tuple[dict, str]:
     cache_path = None
     try:
@@ -692,6 +692,10 @@ async def get_detailed_profile(
             return None, str(e)
         
     return profile, ""
+
+# 获取包含了玩家详细信息的简单卡片控件所需要的filter
+def get_detailed_profile_card_filter(*s: str) -> set[str]:
+    return {'userGamedata', 'userDecks', 'upload_time', 'userCards', *s}
 
 # 从玩家详细信息获取该玩家头像的PlayerAvatarInfo
 async def get_player_avatar_info_by_detailed_profile(ctx: SekaiHandlerContext, detail_profile: dict) -> PlayerAvatarInfo:


### PR DESCRIPTION
在调用get_detailed_profile时传入filter参数，不使用缺省值。可以减少一部分流量消耗，提高速度。
主要修改：
  - 在src/plugins/sekai/modules/profile.py中新加了一个方法get_detailed_profile_card_filter。在原本请求数据所必需的filter的基础上保证合成头像所必须的数据。
  - 修改了get_detailed_profile方法的函数签名，修改filter参数的类型注解
  - 修改了以下文件中调用get_detailed_profile的地方，明确它们的filter参数：src/plugins/sekai/modules/card.py， src/plugins/sekai/modules/deck.py， src/plugins/sekai/modules/education.py， src/plugins/sekai/modules/event.py， src/plugins/sekai/modules/music.py， src/plugins/sekai/modules/mysekai.py。

      