### PR TITLE
[+]谱面预览可以查看技能与fever覆盖情况，还可查看技能和fever的加成效果

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ tencentcloud-sdk-python
 ffmpeg-python
 pdf2image   # also need to install poppler-utils
 uvloop
-pjsekai.scores
+svgwrite
 setproctitle
 bypy
 colour-science

--- a/src/pjsekai/scores/__init__.py
+++ b/src/pjsekai/scores/__init__.py
@@ -1,0 +1,13 @@
+'''
+score Format Specification v2.7 (rev2)
+
+https://gist.github.com/kb10uy/c171c175ba913dc40a73c6ce69da9859
+'''
+
+from .notes import *
+from .types import *
+
+from .score import *
+from .drawing import *
+from .rebase import *
+from .lyric import *

--- a/src/pjsekai/scores/__main__.py
+++ b/src/pjsekai/scores/__main__.py
@@ -1,0 +1,76 @@
+import os
+import argparse
+
+from .__init__ import *
+
+
+class Main:
+    def __init__(self):
+        self.input: str = None
+        self.output: str = None
+        self.score: Score = None
+        self.rebase: Rebase = None
+        self.lyric: Lyric = None
+        self.note_host: str = ''
+        self.css: str = ''
+
+    @classmethod
+    def from_args(cls) -> 'Main':
+        parser = argparse.ArgumentParser()
+        parser.add_argument('score', metavar='<xxx.sus>', help='the pjsekai score file')
+        parser.add_argument('--rebase', metavar='<xxx.json>', help='customized bpm, beats and sections')
+        parser.add_argument('--lyric', metavar='<xxx.txt>', help='lyrics')
+        parser.add_argument('--css', metavar='<xxx.css>', help='style sheets')
+        parser.add_argument('--note-host', dest='note_host', metavar='<url>',
+                            default='https://asset3.pjsekai.moe/live/note/custom01',
+                            help='the base dir of asset files for notes')
+
+        parser.add_argument('-o', '--output', metavar='<xxx.svg>')
+        args = parser.parse_args()
+
+        self = cls()
+        self.input = os.path.abspath(args.score)
+
+        if args.output:
+            if os.path.isdir(args.output):
+                self.output = os.path.join(
+                    os.path.dirname(args.output),
+                    os.path.splitext(self.input)[0] + '.svg',
+                )
+            else:
+                self.output = str(args.output)
+        else:
+            self.output = os.path.join(
+                os.path.dirname(self.input),
+                os.path.splitext(self.input)[0] + '.svg',
+            )
+
+        self.score = Score.open(args.score, encoding='UTF-8')
+
+        if args.rebase:
+            with open(args.rebase, encoding='UTF-8') as f:
+                self.rebase = Rebase.load(f)
+
+        if args.lyric:
+            with open(args.lyric, encoding='UTF-8') as f:
+                self.lyric = Lyric.load(f)
+
+        if args.css:
+            with open(args.css, encoding='UTF-8') as f:
+                self.css = f.read()
+
+        self.note_host = args.note_host
+
+        return self
+
+    def __call__(self):
+        s = self.score
+        if self.rebase:
+            s = self.rebase(self.score)
+
+        d = Drawing(score=s, lyric=self.lyric, style_sheet=self.css, note_host=self.note_host)
+        d.svg().saveas(self.output)
+
+
+if __name__ == '__main__':
+    Main.from_args()()

--- a/src/pjsekai/scores/css/default.css
+++ b/src/pjsekai/scores/css/default.css
@@ -1,0 +1,130 @@
+.bar-line {
+    stroke: #e2e2e2;
+    stroke-width: 4;
+}
+
+.bar-count-flag {
+    stroke: #ffffff;
+    stroke-width: 4;
+}
+
+.bar-count-text {
+    font-size: 12px;
+    font-weight: 900;
+    font-family: Avenir;
+    fill: #ffffff;
+    text-anchor: start;
+}
+
+.beat-line {
+    stroke: #e2e2e2;
+    stroke-width: 1;
+}
+
+.lane-line {
+    stroke: #e2e2e2;
+    stroke-width: 1;
+}
+
+.event-flag {
+    stroke: #fee300;
+    stroke-width: 4;
+}
+
+.event-text {
+    font-size: 12px;
+    font-weight: 900;
+    font-family: Avenir;
+    fill: #fee300;
+    text-anchor: start;
+}
+
+.speed-line {
+    stroke: #ff33ff;
+    stroke-width: 1;
+}
+
+.speed-text {
+    font-size: 12px;
+    font-family: Avenir;
+    fill: #ff33ff;
+    text-anchor: end;
+}
+
+.lyric-text {
+    font-size: 12px;
+    font-family: "ヒラギノ角ゴ Pro W3", "Hiragino Kaku Gothic Pro", Osaka, メイリオ, Meiryo, "ＭＳ Ｐゴシック", "MS PGothic", "ＭＳ ゴシック" , "MS Gothic", "Noto Sans CJK JP", TakaoPGothic, sans-serif;
+    fill: #ffffff;
+    text-anchor: start;
+}
+
+.slide {
+    fill: #c9fce2cc
+}
+
+.slide-critical {
+    fill: #fcf1c3cc
+}
+
+.decoration {
+    fill: url(#decoration-gradient);
+}
+
+#decoration-gradient {
+    --color-start: #c9fce299;
+    --color-stop: #c9fce233;
+}
+
+.decoration-critical {
+    fill: url(#decoration-critical-gradient);
+}
+
+#decoration-critical-gradient {
+    --color-start: #fcf1c399;
+    --color-stop: #fcf1c333;
+}
+
+.tick-text {
+    font-size: 12px;
+    font-family: Avenir;
+    fill: #e2e2e2;
+    text-anchor: end;
+}
+
+.tick-line {
+    stroke: #e2e2e2;
+    stroke-width: 1;
+}
+
+.meta-line {
+    stroke: #e2e2e2;
+    stroke-width: 2;
+}
+
+.title {
+    font-size: 96px;
+    font-weight: 900;
+    font-family: "ヒラギノ角ゴ Pro W3", "Hiragino Kaku Gothic Pro", Osaka, メイリオ, Meiryo, "ＭＳ Ｐゴシック", "MS PGothic", "ＭＳ ゴシック" , "MS Gothic", "Noto Sans CJK JP", TakaoPGothic, sans-serif;
+    fill: #ffffff;
+    text-anchor: start;
+}
+
+.subtitle {
+    font-size: 48px;
+    font-weight: 700;
+    font-family: "ヒラギノ角ゴ Pro W3", "Hiragino Kaku Gothic Pro", Osaka, メイリオ, Meiryo, "ＭＳ Ｐゴシック", "MS PGothic", "ＭＳ ゴシック" , "MS Gothic", "Noto Sans CJK JP", TakaoPGothic, sans-serif;
+    fill: #ffffff;
+    text-anchor: start;
+}
+
+.lane {
+    fill: #d5bdef;
+}
+
+.background {
+    fill: #ab7ed3;
+}
+
+.meta {
+    fill: #ab7ed3;
+}

--- a/src/pjsekai/scores/css/skill.css
+++ b/src/pjsekai/scores/css/skill.css
@@ -1,0 +1,36 @@
+.lane {
+    fill: #CFD8DC;
+}
+
+.background {
+    fill: #FFFFFF;
+}
+
+.meta {
+    fill: #FFFFFF;
+}
+
+.skill-duration {
+    fill: #78909C;
+}
+
+.skill-perfect {
+    fill: #90A4AE;
+}
+
+.skill-great {
+    fill: #B0BEC5;
+}
+
+.skill-score {
+    font-size: 38px;
+    /*font-weight: 900;*/
+    font-family: Osaka;
+    fill: black;
+    text-anchor: start;
+    /*text-shadow: black 0.1em 0.1em 0.2em;*/
+}
+
+.fever-duration {
+    fill: #ECEFF1;
+}

--- a/src/pjsekai/scores/drawing.py
+++ b/src/pjsekai/scores/drawing.py
@@ -1,0 +1,1015 @@
+import os
+import math
+
+import svgwrite
+import svgwrite.base
+import svgwrite.path
+import svgwrite.image
+import svgwrite.shapes
+import svgwrite.text
+import svgwrite.gradients
+import svgwrite.masking
+import svgwrite.container
+
+from .types import *
+from .notes import *
+
+from .score import *
+from .lyric import *
+
+from dataclasses import dataclass
+from typing import Optional
+
+__all__ = ['Drawing', 'DrawingSentence']
+
+
+@dataclass
+class CoverObject:
+    bar_from: Optional[Fraction] = None
+    css_class: Optional[str] = None
+
+@dataclass
+class CoverRect(CoverObject):
+    bar_to: Optional[Fraction] = None
+
+@dataclass
+class CoverText(CoverObject):
+    text: Optional[str] = None
+
+class Drawing:
+
+    def __init__(
+        self,
+        score: Score,
+        lyric: Lyric = None,
+        style_sheet: str = '',
+        note_host: str = 'https://asset3.pjsekai.moe/live/note/custom01',
+        skill: bool = False,
+        music_meta:Optional[dict] = None,
+        **kwargs,
+    ):
+
+        self.score = score
+        self.lyric = lyric
+
+        self.n_lanes = 12
+
+        self.note_host = note_host
+
+        ''''widths'''
+        self.lane_width = 16
+        # self.note_width = 8
+        # self.flick_width = 32
+
+        '''heights'''
+        self.time_height = 360
+        self.note_size = 16
+        self.flick_height = 24
+
+        '''paddings'''
+        self.lane_padding = 40
+        self.time_padding = 32
+
+        # self.padding = 36
+        self.slide_path_padding = -1
+        self.meta_size = 192
+        # self.note_size_ratio = 1.0
+
+        self.tick_length = 24
+        self.tick_2_length = 8
+
+        '''skill'''
+        self.skill = skill
+        self.music_meta = music_meta
+        self.special_cover_objects: list[CoverObject] = []
+        
+
+        with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'css/default.css'), encoding='UTF-8') as f:
+            self.style_sheet = f.read()
+        # 添加技能相关样式
+        if self.skill:
+            with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'css/skill.css'), encoding='UTF-8') as f:
+                self.style_sheet += '\n' + f.read() 
+        # 添加自定义样式
+        self.style_sheet += '\n' + style_sheet
+
+    def __getitem__(self, bar: slice) -> svgwrite.Drawing:
+        bar = slice(bar.start or 0, bar.stop or int(self.score.notes[-1].bar + 1))
+        sentence = DrawingSentence(self, bar)
+        return sentence.svg()
+
+    def svg(self) -> svgwrite.Drawing:
+        n_bars = math.ceil(self.score.notes[-1].bar)
+
+        drawings: list[svgwrite.Drawing] = []
+
+        width = 0
+        height = 0
+
+        bar = 0
+        event = Event(bar=0, bpm=120, bar_length=4, sentence_length=4)
+
+        if self.skill:
+            # Add fever cover object
+            if self.music_meta:
+                for e in self.score.events:
+                    if e.text != 'SUPER FEVER!!':
+                        continue
+                    self.special_cover_objects.append(CoverRect(
+                        e.bar, "fever-duration", self.score.get_bar_by_time(self.music_meta["fever_end_time"])
+                    ))
+                    self.special_cover_objects.append(CoverText(
+                        e.bar, "skill-score", "multi+%.2f%%" % (self.music_meta['fever_score'] * 100)
+                    ))
+
+            # Add skill cover object
+            skill_i = 0
+            for e in self.score.events:
+                if e.text != "SKILL":
+                    continue
+                # print(e)
+                self.special_cover_objects.append(CoverRect(
+                    self.score.get_bar_by_time(self.score.get_time(e.bar) - 5 / 60),
+                    "skill-great",
+                    self.score.get_bar_by_time(self.score.get_time(e.bar) + 5 + 5 / 60)
+                ))
+                self.special_cover_objects.append(CoverRect(
+                    self.score.get_bar_by_time(self.score.get_time(e.bar) - 2.5 / 60),
+                    "skill-perfect",
+                    self.score.get_bar_by_time(self.score.get_time(e.bar) + 5 + 2.5 / 60)
+                ))
+                self.special_cover_objects.append(CoverRect(
+                    e.bar,
+                    "skill-duration",
+                    self.score.get_bar_by_time(self.score.get_time(e.bar) + 5)
+                ))
+                if self.music_meta:
+                    solo_skill_score = "+%.2f%%" % (self.music_meta['skill_score_solo'][skill_i] * 100)
+                    multi_skill_score = "+%.2f%%" % (self.music_meta['skill_score_multi'][skill_i] * 100)
+                    append_text = solo_skill_score
+                    if solo_skill_score != multi_skill_score:
+                        append_text = "solo%s multi%s" % (solo_skill_score, multi_skill_score)
+                    self.special_cover_objects.append(CoverText(
+                        e.bar, "skill-score", append_text
+                    ))
+                skill_i += 1
+            pass
+
+        for i in range(n_bars + 1):
+            e = self.score.get_event(i)
+
+            if bar != i and (
+                e.section != event.section or
+                e.sentence_length != event.sentence_length or
+                i == bar + event.sentence_length or
+                i == n_bars
+            ):
+                d = self[bar: i]
+
+                width += d['width']
+                if height < d['height']:
+                    height = d['height']
+
+                drawings.append(d)
+
+                bar = i
+
+            event |= e
+
+        drawing = svgwrite.Drawing(size=(
+            width + self.lane_padding * 2,
+            height + self.time_padding * 2 + self.meta_size + self.time_padding * 2,
+        ))
+
+        drawing.defs.add(drawing.style(self.style_sheet))
+
+        decoration_gradient = svgwrite.gradients.LinearGradient(
+            start=(0, 1), end=(0, 0), id='decoration-gradient', debug=False)
+        decoration_gradient.add_stop_color(offset=0, color='var(--color-start)')
+        decoration_gradient.add_stop_color(offset=1, color='var(--color-stop)')
+        drawing.defs.add(decoration_gradient)
+
+        decoration_critical_gradient = svgwrite.gradients.LinearGradient(
+            start=(0, 1), end=(0, 0), id='decoration-critical-gradient', debug=False)
+        decoration_critical_gradient.add_stop_color(offset=0, color='var(--color-start)')
+        decoration_critical_gradient.add_stop_color(offset=1, color='var(--color-stop)')
+        drawing.defs.add(decoration_critical_gradient)
+
+        # tap_left = svgwrite.masking.ClipPath(id="tap-left")
+        # tap_left.add(svgwrite.shapes.Rect(size=(100, 100)))
+        # drawing.defs.add(tap_left)
+
+        note_m_ratio = 1200
+        for note_number in range(0, 7):
+            symbol = svgwrite.container.Symbol(
+                id=f'notes-{note_number}',
+                viewBox='0 0 112 56',
+            )
+            symbol.add(svgwrite.image.Image(
+                href=f'{self.note_host}/notes_{note_number}.png',
+                insert=(-3, -3),
+                size=(118, 62),
+            ))
+            drawing.defs.add(symbol)
+
+            symbol = svgwrite.container.Symbol(
+                id=f'notes-{note_number}-middle',
+                viewBox=f'0 0 {112 * note_m_ratio} {56}',
+            )
+            symbol.add(svgwrite.image.Image(
+                href=f'{self.note_host}/notes_{note_number}.png',
+                insert=(-(3 + 28) * note_m_ratio, -3), size=(118 * note_m_ratio, 62),
+                preserveAspectRatio='none',
+            ))
+            drawing.defs.add(symbol)
+
+            for i in range(1, self.n_lanes + 1):
+                note_height = self.note_size
+                note_width = self.lane_width * (i + 1)
+                note_inner_width = self.lane_width * i
+
+                note_l_width = note_r_width = note_height / 56 * 32
+                note_m_width = note_inner_width - (note_l_width + note_r_width) / 2 - 2
+                note_padding_x = (note_width - note_l_width - note_m_width - note_r_width) / 2
+
+                symbol = svgwrite.container.Symbol(
+                    id=f'notes-{note_number}-{i}', viewBox=f'0 0 {note_width} {note_height}')
+
+                left_clip_path = svgwrite.masking.ClipPath(id=f'notes-{note_number}-{i}-left')
+                left_clip_path.add(svgwrite.shapes.Rect(
+                    insert=(0, 0),
+                    size=(note_l_width, note_height),
+                ))
+                symbol.add(left_clip_path)
+
+                middle_clip_path = svgwrite.masking.ClipPath(id=f'notes-{note_number}-{i}-middle')
+                middle_clip_path.add(svgwrite.shapes.Rect(
+                    insert=(0, 0),
+                    size=(note_m_width, note_height),
+                ))
+                symbol.add(middle_clip_path)
+
+                right_clip_path = svgwrite.masking.ClipPath(id=f'notes-{note_number}-{i}-right')
+                right_clip_path.add(svgwrite.shapes.Rect(
+                    insert=(note_height / 56 * 80, 0),
+                    size=(note_r_width, note_height),
+                ))
+                symbol.add(right_clip_path)
+
+                symbol.add(svgwrite.container.Use(
+                    href=f'#notes-{note_number}',
+                    insert=(note_padding_x, 0),
+                    size=(note_height * 2, note_height),
+                    clip_path=f'url(#notes-{note_number}-{i}-left)',
+                ))
+                symbol.add(svgwrite.container.Use(
+                    href=f'#notes-{note_number}-middle',
+                    insert=(note_padding_x + note_l_width, 0),
+                    size=(note_height * note_m_ratio * 2, note_height),
+                    clip_path=f'url(#notes-{note_number}-{i}-middle)',
+                ))
+                symbol.add(svgwrite.container.Use(
+                    href=f'#notes-{note_number}',
+                    insert=(note_padding_x + note_l_width + note_m_width + note_r_width - note_height * 2, 0),
+                    size=(note_height * 2, note_height),
+                    clip_path=f'url(#notes-{note_number}-{i}-right)',
+                ))
+
+                drawing.defs.add(symbol)
+
+        drawing.add(drawing.rect(
+            insert=(0, 0),
+            size=(
+                width + self.lane_padding * 2,
+                height + self.time_padding * 2,
+            ),
+            class_='background',
+        ))
+
+        drawing.add(drawing.rect(
+            insert=(0, height + self.time_padding * 2),
+            size=(
+                width + self.lane_padding * 2,
+                self.meta_size + self.time_padding * 2,
+            ),
+            class_='meta',
+        ))
+
+        drawing.add(drawing.line(
+            start=(
+                0,
+                height + self.time_padding * 2,
+            ),
+            end=(
+                width + self.lane_padding * 2,
+                height + self.time_padding * 2,
+            ),
+            class_='meta-line',
+        ))
+
+        drawing.add(svgwrite.image.Image(
+            href=self.score.meta.jacket or 'https://storage.sekai.best/sekai-jp-assets/thumbnail/chara_rip/res009_no021_normal.png',
+            insert=(
+                self.lane_padding * 2,
+                height + self.time_padding * 3,
+            ),
+            size=(self.meta_size, self.meta_size),
+        ))
+
+        drawing.add(svgwrite.text.Text(
+            ' - '.join(filter(lambda x: x, [
+                self.score.meta.title,
+                self.score.meta.artist,
+            ])) or 'Untitled',
+            insert=(
+                self.meta_size + self.lane_padding * 4,
+                self.meta_size + height + self.time_padding * 3 - 16,
+            ),
+            class_='title',
+        ))
+
+        drawing.add(svgwrite.text.Text(
+            ' '.join(filter(lambda x: x, [
+                self.score.meta.difficulty and str(self.score.meta.difficulty).upper(),
+                self.score.meta.playlevel,
+                'Chart by sekai.best powered by pjsekai.moe'
+            ])),
+            insert=(
+                self.meta_size + self.lane_padding * 4,
+                self.meta_size * 1/3 + height + self.time_padding * 3 - 8,
+            ),
+            class_='subtitle',
+        ))
+
+        # scale = self.scale()
+        # scale['x'] = width - self.meta_size
+        # scale['y'] = height + self.padding * 2
+        # drawing.add(scale)
+        
+        # 来自33源码中的水印
+        drawing.add(svgwrite.text.Text(
+            'Code by ぷろせかもえ！ (pjsekai.moe)　& Unibot',
+            insert=(
+                width - 900,
+                height + self.lane_padding * 4.2,
+            ),
+            class_='themehint',
+        ))
+        drawing.add(svgwrite.text.Text(
+            'Modified by 33 (3-3.dev & bilibili @xfl03)',
+            insert=(
+                width - 770,
+                height + self.lane_padding * 5.9,
+            ),
+            class_='themehint',
+        ))
+
+
+        width = 0
+        for d in drawings:
+            d['x'] = width + self.lane_padding
+            d['y'] = height - d['height'] + self.time_padding
+            width += d['width']
+            drawing.add(d)
+
+        return drawing
+
+
+class DrawingSentence(Drawing):
+
+    def __init__(self, drawing: Drawing, bar: slice):
+        self.bar = bar
+
+        self.slide_paths = []
+        self.among_images = []
+        self.note_images = []
+        self.flick_images = []
+        self.tick_texts = []
+
+        for k, v in vars(drawing).items():
+            self.__setattr__(k, v)
+
+    def _get_bezier_coordinates(self, slide_0: Slide, slide_1: Slide):
+        # Bézier curve:
+        # left: from l[0], controlled by l[1] and l[2], to l[3]
+        # right: from r[0], controlled by r[1] and r[2], to r[3]
+
+        y_0 = self.time_height * self.score.get_time_delta(slide_0.bar, self.bar.stop) + self.time_padding
+        y_1 = self.time_height * self.score.get_time_delta(slide_1.bar, self.bar.stop) + self.time_padding
+
+        ease_in = slide_0.directional and slide_0.directional.type in (
+            DirectionalType.DOWN, )
+        ease_out = slide_0.directional and slide_0.directional.type in (
+            DirectionalType.LOWER_LEFT, DirectionalType.LOWER_RIGHT)
+
+        slide_path_padding = self.slide_path_padding if not slide_0.decoration else 0
+
+        return (
+            (
+                self.lane_width * (slide_0.lane - 2) + self.lane_padding - slide_path_padding,
+                y_0,
+            ),
+            (
+                self.lane_width * (slide_0.lane - 2) + self.lane_padding - slide_path_padding,
+                (y_0 + y_1) / 2 if ease_in else y_0,
+            ),
+            (
+                self.lane_width * (slide_1.lane - 2) + self.lane_padding - slide_path_padding,
+                (y_0 + y_1) / 2 if ease_out else y_1,
+            ),
+            (
+                self.lane_width * (slide_1.lane - 2) + self.lane_padding - slide_path_padding,
+                y_1,
+            ),
+        ), (
+            (
+                self.lane_width * (slide_0.lane - 2 + slide_0.width) + self.lane_padding + slide_path_padding,
+                y_0,
+            ),
+            (
+                self.lane_width * (slide_0.lane - 2 + slide_0.width) + self.lane_padding + slide_path_padding,
+                (y_0 + y_1) / 2 if ease_in else y_0,
+            ),
+            (
+                self.lane_width * (slide_1.lane - 2 + slide_1.width) + self.lane_padding + slide_path_padding,
+                (y_0 + y_1) / 2 if ease_out else y_1,
+            ),
+            (
+                self.lane_width * (slide_1.lane - 2 + slide_1.width) + self.lane_padding + slide_path_padding,
+                y_1,
+            )
+        )
+
+    def add_slide_path(self, slide: Slide):
+        lefts, rights = [], []
+        slide_0: Slide = slide
+
+        while slide_0.type != SlideType.END:
+            amongs = []
+            slide_1: Slide = slide_0.next
+            while True:
+                if slide_1.type == SlideType.RELAY:
+                    amongs.append(slide_1)
+
+                if slide_1.is_path():
+                    break
+
+                slide_1 = slide_1.next
+
+            l, r = self._get_bezier_coordinates(slide_0, slide_1)
+            lefts.append(l)
+            rights.append(r)
+
+            for among in amongs:
+                self.add_among_image(among, l, r)
+
+            slide_0 = slide_1
+
+        d = [
+            [
+                [
+                    ('M', list(map(round, [*l[0]]))) if i == 0 else [],
+                    ('C', list(map(round, [*l[1], *l[2], *l[3]])))
+                ]
+                for i, l in enumerate(lefts)
+            ],
+            [
+                [
+                    ('L', list(map(round, [*r[3]]))) if i == 0 else [],
+                    ('C', list(map(round, [*r[2], *r[1], *r[0]])))
+                ]
+                for i, r in enumerate(reversed(rights))
+            ],
+            ('z'),
+        ]
+
+        class_name: str
+        if slide.decoration:
+            class_name = 'decoration-critical' if slide.is_critical() else 'decoration'
+        else:
+            class_name = 'slide-critical' if slide.is_critical() else 'slide'
+
+        self.slide_paths.append(
+            svgwrite.path.Path(
+                d=d,
+                class_=class_name,
+            ),
+        )
+
+    def add_friction_among_image(self, note: Note):
+        y = self.time_height * self.score.get_time_delta(note.bar, self.bar.stop) + self.time_padding
+        x = self.lane_width * (note.lane + note.width / 2 - 2) + self.lane_padding
+
+        w = self.lane_width * 0.75
+        h = self.lane_width * 0.75
+
+        self.among_images.append(svgwrite.image.Image(
+            href='%s/notes_friction_among%s.png' % (
+                self.note_host,
+                '_crtcl' if note.is_critical() else '_flick' if isinstance(note, Directional) else '_long',
+            ),
+            insert=(
+                round(x - w / 2),
+                round(y - h / 2),
+            ),
+            size=(
+                round(w),
+                round(h),
+            ),
+        ))
+
+    def add_among_image(self, note: Note, l, r):
+        y = self.time_height * self.score.get_time_delta(note.bar, self.bar.stop) + self.time_padding
+
+        x_l = _binary_solution_for_x(y, l)
+        x_r = _binary_solution_for_x(y, r)
+        x = (x_l + x_r) / 2
+
+        w = self.lane_width
+        h = self.lane_width
+
+        self.among_images.append(svgwrite.image.Image(
+            href='%s/notes_long_among%s.png' % (
+                self.note_host,
+                '_crtcl' if note.is_critical() else '',
+            ),
+            insert=(
+                round(x - w / 2),
+                round(y - h / 2),
+            ),
+            size=(
+                round(w),
+                round(h),
+            ),
+        ))
+
+    def add_note_images(self, note: Note):
+        y = self.time_height * self.score.get_time_delta(note.bar, self.bar.stop) + self.time_padding
+        x = self.lane_width * (note.lane - 2.5) + self.lane_padding
+
+        w = self.lane_width * (note.width + 1)
+        h = self.lane_width / 64 * 56 * 2
+
+        note_number = 2
+
+        if note.is_none():
+            return
+        elif note.is_trend():
+            self.add_friction_among_image(note)
+            if note.is_critical():
+                note_number = 5
+            elif isinstance(note, Directional):
+                note_number = 6
+            else:
+                note_number = 4
+        else:
+            if note.is_critical():
+                note_number = 0
+            elif isinstance(note, Directional):
+                note_number = 3
+            elif isinstance(note, Slide):
+                if note.type == SlideType.END and note.directional:
+                    note_number = 3
+                else:
+                    note_number = 1
+
+        self.note_images.append(svgwrite.container.Use(
+            href=f'#notes-{note_number}-{note.width}',
+            insert=(round(x), round(y - h / 2)),
+            size=(round(w), round(h)),
+        ))
+
+    def add_flick_image(self, note: Note):
+        src = '%s/notes_flick_arrow%s_0%s%s.png'
+        y = self.time_height * self.score.get_time_delta(note.bar, self.bar.stop) + self.time_padding
+
+        if note.is_none():
+            return
+
+        type = DirectionalType.UP
+        if isinstance(note, Directional):
+            if note.type == DirectionalType.UPPER_LEFT:
+                type = DirectionalType.UPPER_LEFT
+            elif note.type == DirectionalType.UPPER_RIGHT:
+                type = DirectionalType.UPPER_RIGHT
+        elif isinstance(note, Slide):
+            if note.directional.type == DirectionalType.UPPER_LEFT:
+                type = DirectionalType.UPPER_LEFT
+            elif note.directional.type == DirectionalType.UPPER_RIGHT:
+                type = DirectionalType.UPPER_RIGHT
+            elif note.directional.type == DirectionalType.UP:
+                type = DirectionalType.UP
+            else:
+                type = None
+
+        if type is None:
+            return
+
+        width = note.width if note.width < 6 else 6
+
+        h0 = self.flick_height
+        h = h0 * ((width + 3) / 3) ** 0.75
+        w = h0 * 1.5 * ((width + 0.5) / 3) ** 0.75
+        x = self.lane_width * (note.lane - 2 + note.width / 2) + self.lane_padding
+        bias = (
+            - self.note_size / 4 if type == DirectionalType.UPPER_LEFT else
+            self.note_size / 4 if type == DirectionalType.UPPER_RIGHT else
+            0
+        )
+
+        self.flick_images.append(svgwrite.image.Image(
+            src % (
+                self.note_host,
+                '_crtcl' if note.is_critical() else '',
+                width,
+                '_diagonal' if type in (DirectionalType.UPPER_LEFT, DirectionalType.UPPER_RIGHT) else ''
+            ),
+            size=(
+                round(w),
+                round(h),
+            ),
+            insert=(
+                round(x - w / 2 + bias),
+                round(y + self.note_size / 4 - h),
+            ),
+            transform_origin=f'{round(x + bias)} 0' if type == DirectionalType.UPPER_RIGHT else None,
+            transform='scale(-1, 1)' if type == DirectionalType.UPPER_RIGHT else None,
+            debug=False,
+        ))
+
+    def add_tick_text(self, note: Note, next: Note | None = None):
+        y = self.time_height * self.score.get_time_delta(note.bar, self.bar.stop) + self.time_padding
+
+        if next is None:
+            self.tick_texts.append(svgwrite.shapes.Line(
+                start=(
+                    round(self.lane_padding - self.tick_2_length),
+                    round(y),
+                ),
+                end=(
+                    round(self.lane_padding),
+                    round(y),
+                ),
+                class_='tick-line',
+            ))
+            return
+
+        if (
+            next is None or
+            next is note or
+            next.bar == note.bar or
+            next.bar - note.bar > 1 or
+            next.bar - note.bar > 0.5 and int(next.bar) != int(note.bar)
+        ):
+            interval = math.floor(note.bar + 1) - note.bar
+        else:
+            interval = next.bar - note.bar
+
+        interval = interval * self.score.get_event(note.bar).bar_length / 4
+        interval = interval.limit_denominator(100)
+
+        if interval == 0:
+            return
+
+        text = '%g/%g' % (interval.numerator, interval.denominator) if interval.numerator != 1 else \
+            '/%g' % (interval.denominator,)
+
+        self.tick_texts.append(svgwrite.shapes.Line(
+            start=(
+                round(self.lane_padding - self.tick_length),
+                round(y),
+            ),
+            end=(
+                round(self.lane_padding),
+                round(y),
+            ),
+            class_='tick-line',
+        ))
+        self.tick_texts.append(svgwrite.text.Text(
+            text,
+            insert=(
+                round(self.lane_padding - 4),
+                round(y - 2),
+            ),
+            class_='tick-text',
+        ))
+        
+    def svg(self):
+        for i, note in enumerate(self.score.notes):
+            if isinstance(note, Slide):
+                slide: Slide = note.head
+                before = None
+                while slide:
+                    while not slide.is_path():
+                        slide = slide.next
+
+                    if self.bar.start - 1 <= slide.bar < self.bar.stop + 1:  # in
+                        break
+                    elif slide.bar < self.bar.start - 1:  # before
+                        before = True
+                    elif before and self.bar.stop + 1 < slide.bar:  # after
+                        break
+
+                    slide = slide.next
+                else:
+                    continue
+
+            else:
+                if not self.bar.start - 1 <= note.bar < self.bar.stop + 1:
+                    continue
+
+            if note.is_tick() is not None:
+                next_tick: Note
+                if note.is_tick():
+                    for next_tick in self.score.notes[i:]:
+                        if next_tick.is_tick() and next_tick.bar > note.bar:
+                            break
+                    else:
+                        next_tick = note
+                else:
+                    next_tick = None
+
+                self.add_tick_text(note, next=next_tick)
+
+            if isinstance(note, Tap):
+                self.add_note_images(note)
+
+            elif isinstance(note, Directional):
+                self.add_flick_image(note)
+                self.add_note_images(note)
+
+            elif isinstance(note, Slide) and not note.decoration:
+                if note.type == SlideType.START:
+                    self.add_slide_path(note)
+                    self.add_note_images(note)
+
+                elif note.type == SlideType.END:
+                    if note.directional:
+                        self.add_flick_image(note)
+                    self.add_note_images(note)
+
+                elif note.type == SlideType.RELAY:
+                    ...
+
+                elif note.type == SlideType.INVISIBLE:
+                    ...
+
+            elif isinstance(note, Slide) and note.decoration:
+                if note.type == SlideType.START:
+                    self.add_slide_path(note)
+
+                elif note.type == SlideType.END:
+                    ...
+
+                elif note.type == SlideType.RELAY:
+                    ...
+
+                elif note.type == SlideType.INVISIBLE:
+                    ...
+
+                if note.tap:
+                    self.add_note_images(note.tap)
+                    if note.directional:
+                        self.add_flick_image(note)
+
+        height = self.time_height * self.score.get_time_delta(self.bar.start, self.bar.stop)
+
+        drawing = svgwrite.Drawing(
+            size=(
+                round(self.lane_width * self.n_lanes + self.lane_padding * 2),
+                round(height + self.time_padding * 2),
+            ),
+        )
+
+        drawing.add(drawing.rect(
+            insert=(0, 0),
+            size=(
+                round(self.lane_width * self.n_lanes + self.lane_padding * 2),
+                round(height + self.time_padding * 2),
+            ),
+            class_='background',
+        ))
+
+        drawing.add(drawing.rect(
+            insert=(self.lane_padding, 0),
+            size=(
+                round(self.lane_width * self.n_lanes),
+                round(height + self.time_padding * 2),
+            ),
+            class_='lane',
+        ))
+        # Draw special cover object under notes
+        for cover_object in self.special_cover_objects:
+            if isinstance(cover_object, CoverText):
+                cover_bar_from = cover_object.bar_from
+                if cover_bar_from < self.bar.start - 0.2 or cover_bar_from >= self.bar.stop - 0.1:
+                    continue
+                drawing.add(drawing.text(
+                    cover_object.text,
+                    insert=(
+                        self.lane_width * self.n_lanes + self.lane_padding * 2 -3,
+                        round(self.time_height * self.score.get_time_delta(cover_bar_from, self.bar.stop) + self.time_padding)
+                    ),
+                    transform=f'''rotate(-90, {
+                        round(self.lane_width * self.n_lanes + self.lane_padding * 2 - 3)
+                    }, {
+                        round(self.time_height * self.score.get_time_delta(cover_bar_from, self.bar.stop) + self.time_padding)
+                    })''',
+                    class_=cover_object.css_class
+                ))
+            elif isinstance(cover_object, CoverRect):
+                cover_bar_from = max(self.bar.start - 0.2, cover_object.bar_from)
+                cover_bar_to = min(self.bar.stop + 0.2, cover_object.bar_to)
+                if cover_bar_to <= cover_bar_from:
+                    continue
+                drawing.add(drawing.rect(
+                    insert=(
+                        self.lane_padding,
+                        round(self.time_height * self.score.get_time_delta(cover_bar_to, self.bar.stop) + self.time_padding),
+                    ),
+                    size=(
+                        round(self.lane_width * self.n_lanes),
+                        round(self.time_height * self.score.get_time_delta(cover_bar_from, cover_bar_to))
+                    ),
+                    class_=cover_object.css_class
+                ))
+
+        for lane in range(0, self.n_lanes + 1, 2):
+            drawing.add(drawing.line(
+                start=(
+                    round(self.lane_width * lane + self.lane_padding),
+                    round(0),
+                ),
+                end=(
+                    round(self.lane_width * lane + self.lane_padding),
+                    round(height + self.time_padding * 2),
+                ),
+                class_='lane-line',
+            ))
+
+        for bar in range(self.bar.start, self.bar.stop + 1):
+            drawing.add(drawing.line(
+                start=(
+                    round(self.lane_width * 0 + self.lane_padding),
+                    round(self.time_height * self.score.get_time_delta(bar, self.bar.stop) + self.time_padding),
+                ),
+                end=(
+                    round(self.lane_width * self.n_lanes + self.lane_padding),
+                    round(self.time_height * self.score.get_time_delta(bar, self.bar.stop) + self.time_padding),
+                ),
+                class_='bar-line',
+            ))
+
+            event = self.score.get_event(bar)
+            for i in range(1, math.ceil(event.bar_length)):
+                t = self.score.get_time_delta(bar + Fraction(i, event.bar_length), self.bar.stop)
+                y = self.time_height * t + self.time_padding
+
+                drawing.add(drawing.line(
+                    start=(
+                        round(self.lane_width * 0 + self.lane_padding),
+                        round(y),
+                    ),
+                    end=(
+                        round(self.lane_width * self.n_lanes + self.lane_padding),
+                        round(y),
+                    ),
+                    class_='beat-line',
+                ))
+
+        print_events: list[Event] = []
+        for event in sorted([Event(bar=i) for i in range(self.bar.start, self.bar.stop + 1)] + self.score.events):
+            if event.speed:
+                drawing.add(drawing.line(
+                    start=(
+                        round(self.lane_width * 0 + self.lane_padding),
+                        round(self.time_height * self.score.get_time_delta(event.bar, self.bar.stop) + self.time_padding),
+                    ),
+                    end=(
+                        round(self.lane_width * self.n_lanes + self.lane_padding),
+                        round(self.time_height * self.score.get_time_delta(event.bar, self.bar.stop) + self.time_padding),
+                    ),
+                    class_='speed-line',
+                ))
+
+                drawing.add(drawing.text(
+                    '%gx' % event.speed,
+                    insert=(
+                        round(self.lane_width * self.n_lanes + self.lane_padding - 2),
+                        round(self.time_height * self.score.get_time_delta(event.bar, self.bar.stop) + self.time_padding - 2),
+                    ),
+                    class_='speed-text',
+                ))
+
+                continue
+
+            if print_events and event.bar - print_events[-1].bar <= 1 / 16:
+                print_events[-1] |= event
+            else:
+                print_events.append(event)
+
+            special = event.bpm or event.bar_length or event.speed or event.section or event.text
+
+            drawing.add(drawing.line(
+                start=(
+                    round(self.lane_width * 0),
+                    round(self.time_height * self.score.get_time_delta(event.bar, self.bar.stop) + self.time_padding),
+                ),
+                end=(
+                    round(self.lane_width * 0 + self.lane_padding),
+                    round(self.time_height * self.score.get_time_delta(event.bar, self.bar.stop) + self.time_padding),
+                ),
+                class_='bar-count-flag' if not special else 'event-flag',
+            ))
+
+        for event in print_events:
+            if not self.bar.start - 1 <= event.bar < self.bar.stop + 1:
+                continue
+
+            text = ', '.join(filter(lambda x: x, [
+                '#%g' % event.bar if int(event.bar) == event.bar else None,
+                '%g BPM' % event.bpm if event.bpm else None,
+                '%g/4' % event.bar_length if event.bar_length else None,
+                event.section,
+                event.text,
+            ]))
+
+            special = event.bpm or event.bar_length or event.speed or event.section or event.text
+
+            if not text:
+                continue
+
+            drawing.add(drawing.text(
+                text,
+                insert=(
+                    round(self.lane_padding + 8),
+                    round(self.time_height * self.score.get_time_delta(event.bar,
+                          self.bar.stop) + self.time_padding - self.lane_width * 1.5),
+                ),
+                transform=f'''rotate(-90, {
+                    round(self.lane_padding)
+                }, {
+                    round(self.time_height * self.score.get_time_delta(event.bar, self.bar.stop) + self.time_padding)
+                })''',
+                class_='bar-count-text' if not special else 'event-text',
+            ))
+
+        if self.lyric:
+            for word in self.lyric.words:
+                if not self.bar.start - 1 <= word.bar < self.bar.stop + 1:
+                    continue
+
+                drawing.add(drawing.text(
+                    word.text,
+                    insert=(
+                        round(self.lane_width * self.n_lanes + self.lane_padding),
+                        round(self.time_height * self.score.get_time_delta(word.bar, self.bar.stop) + self.time_padding + 16),
+                    ),
+                    transform=f'''rotate(-90, {
+                        round(self.lane_width * self.n_lanes + self.lane_padding)
+                    }, {
+                        round(self.time_height * self.score.get_time_delta(word.bar, self.bar.stop) + self.time_padding)
+                    })''',
+                    class_='lyric-text',
+                ))
+
+        for slide_path in self.slide_paths:
+            drawing.add(slide_path)
+
+        for tap_image in self.note_images:
+            drawing.add(tap_image)
+
+        for among_image in self.among_images:
+            drawing.add(among_image)
+
+        for flick_image in reversed(self.flick_images):
+            drawing.add(flick_image)
+
+        for tick_text in self.tick_texts:
+            drawing.add(tick_text)
+
+        return drawing
+
+
+def _binary_solution_for_x(y, curve: list[tuple], s: slice = None, e=0.1):
+    if s is None:
+        s = slice(0, 1)
+
+    t = (s.start + s.stop) / 2
+    p = [(
+        curve[0][k] * (1 - t) ** 3 * t ** 0 * 1 +
+        curve[1][k] * (1 - t) ** 2 * t ** 1 * 3 +
+        curve[2][k] * (1 - t) ** 1 * t ** 2 * 3 +
+        curve[3][k] * (1 - t) ** 0 * t ** 3 * 1
+    ) for k in range(2)]
+
+    # print(y, s, p)
+
+    if y - e < p[1] < y + e:
+        return p[0]
+    elif p[1] > y:
+        return _binary_solution_for_x(y, curve, slice(t, s.stop))
+    elif p[1] < y:
+        return _binary_solution_for_x(y, curve, slice(s.start, t))
+    else:
+        raise NotImplementedError

--- a/src/pjsekai/scores/line.py
+++ b/src/pjsekai/scores/line.py
@@ -1,0 +1,158 @@
+import re
+
+from .notes import *
+from .types import *
+
+from .meta import *
+
+
+@dataclasses.dataclass
+class BpmDefinition:
+    id: int
+    bpm: Fraction
+
+
+@dataclasses.dataclass
+class BpmReference(BaseNote):
+    id: int
+
+
+@dataclasses.dataclass
+class SpeedDefinitionItem:
+    bar: int
+    tick: int
+    speed: float
+
+
+@dataclasses.dataclass
+class SpeedDefinition:
+    id: int
+    items: list[SpeedDefinitionItem]
+
+
+@dataclasses.dataclass
+class SpeedControl:
+    id: int | None
+
+
+class TicksPerBeat(int):
+    ...
+
+
+class Line:
+    type: str
+    header: str
+    data: str
+
+    def __init__(self, line: str):
+        line = line.strip()
+
+        if match := re.match(r'^#(\w+)\s+(.*)$', line):
+            self.type = 'meta'
+            self.header, self.data = match.groups()
+
+        elif match := re.match(r'^#(\w+):\s*(.*)$', line):
+            self.type = 'score'
+            self.header, self.data = match.groups()
+
+        else:
+            self.type = 'comment'
+            self.header, self.data = 'comment', line
+
+    def parse(self):
+        match self.type:
+            case 'meta': return self.parse_meta()
+            case 'score': return self.parse_score()
+            case _: return []
+
+    def parse_meta(self):
+        meta = Meta()
+        if hasattr(meta, self.header.lower()):
+            try:
+                data = eval(self.data)
+            except:
+                data = self.data
+            setattr(meta, self.header.lower(), data)
+            yield meta
+
+        elif self.header == 'REQUEST':
+            if match := re.match(r'^"ticks_per_beat\s+(\d+)"$', self.data):
+                yield TicksPerBeat(int(match.group(1)))
+
+        elif self.header == 'HISPEED':
+            yield SpeedControl(int(self.data, 36))
+
+        elif self.header == 'NOSPEED':
+            yield SpeedControl(None)
+
+    def parse_score(self):
+        if match := re.match(r'^(\d\d\d)02$', self.header):
+            yield Event(bar=int(match.group(1)), bar_length=int(self.data))
+
+        elif match := re.match(r'^BPM(..)$', self.header):
+            yield BpmDefinition(id=int(match.group(1), 36), bpm=Fraction(self.data))
+
+        elif match := re.match(r'^(\d\d\d)08$', self.header):
+            for beat, data in self.parse_score_data():
+                yield BpmReference(bar=int(match.group(1)) + beat, id=int(data, 36))
+
+        elif match := re.match(r'^TIL(..)$', self.header):
+            id = int(match.group(1), 36)
+            data: str = eval(self.data)
+            items = []
+            if data:
+                for item in data.split(','):
+                    match = re.match(r'(\d+)\'(\d+):(\S+)', item.strip())
+                    item = SpeedDefinitionItem(
+                        bar=int(match.group(1)),
+                        tick=int(match.group(2)),
+                        speed=float(match.group(3)),
+                    )
+                    items.append(item)
+
+            yield SpeedDefinition(id=id, items=sorted(items, key=lambda item: (item.bar, item.tick)))
+
+        elif match := re.match(r'^(\d\d\d)1(.)$', self.header):
+            for beat, data in self.parse_score_data():
+                yield Tap(
+                    bar=int(match.group(1)) + beat,
+                    lane=int(match.group(2), 36),
+                    width=int(data[1], 36),
+                    type=int(data[0], 36),
+                )
+
+        elif match := re.match(r'^(\d\d\d)3(.)(.)$', self.header):
+            for beat, data in self.parse_score_data():
+                yield Slide(
+                    bar=int(match.group(1)) + beat,
+                    lane=int(match.group(2), 36),
+                    width=int(data[1], 36),
+                    type=int(data[0], 36),
+                    channel=int(match.group(3), 36),
+                    decoration=False,
+                )
+
+        elif match := re.match(r'^(\d\d\d)5(.)$', self.header):
+            for beat, data in self.parse_score_data():
+                yield Directional(
+                    bar=int(match.group(1)) + beat,
+                    lane=int(match.group(2), 36),
+                    width=int(data[1], 36),
+                    type=int(data[0], 36),
+                )
+
+        elif match := re.match(r'^(\d\d\d)9(.)(.)$', self.header):
+            for beat, data in self.parse_score_data():
+                yield Slide(
+                    bar=int(match.group(1)) + beat,
+                    lane=int(match.group(2), 36),
+                    width=int(data[1], 36),
+                    type=int(data[0], 36),
+                    channel=int(match.group(3), 36),
+                    decoration=True,
+                )
+
+    def parse_score_data(self):
+        for i in range(0, len(self.data), 2):
+            if self.data[i: i+2] != '00':
+                yield Fraction(i, len(self.data)), self.data[i: i+2]

--- a/src/pjsekai/scores/lyric.py
+++ b/src/pjsekai/scores/lyric.py
@@ -1,0 +1,36 @@
+import dataclasses
+import re
+
+from .types import *
+
+__all__ = ['Word', 'Lyric']
+
+
+@dataclasses.dataclass
+class Word:
+    bar: float
+    text: str
+
+
+class Lyric:
+    def __init__(self):
+        self.words: list[Word] = []
+
+    @classmethod
+    def load(cls, f):
+        self = cls()
+        lines: list[str] = f.readlines()
+
+        for line in lines:
+            line = line.strip()
+            if match := re.match(r'^(\d+): (.*)$', line):
+                bar = int(match.group(1))
+                texts = match.group(2).split('/')
+                for i, text in enumerate(texts):
+                    if text:
+                        self.words.append(Word(
+                            bar=bar + Fraction(i, len(texts)),
+                            text=text
+                        ))
+
+        return self

--- a/src/pjsekai/scores/meta.py
+++ b/src/pjsekai/scores/meta.py
@@ -1,0 +1,41 @@
+import typing
+import dataclasses
+
+
+@dataclasses.dataclass
+class Meta:
+    title: typing.Optional[str] = None
+    subtitle: typing.Optional[str] = None
+    artist: typing.Optional[str] = None
+    genre: typing.Optional[str] = None
+    designer: typing.Optional[str] = None
+    difficulty: typing.Optional[str] = None
+    playlevel: typing.Optional[str] = None
+    songid: typing.Optional[str] = None
+    wave: typing.Optional[str] = None
+    waveoffset: typing.Optional[str] = None
+    jacket: typing.Optional[str] = None
+    background: typing.Optional[str] = None
+    movie: typing.Optional[str] = None
+    movieoffset: typing.Optional[float] = None
+    basebpm: typing.Optional[float] = None
+    # requests: list = dataclasses.field(default_factory=list)
+
+    def __or__(self, other: 'Meta') -> 'Meta':
+        return Meta(
+            title=self.title or other.title,
+            subtitle=self.subtitle or other.subtitle,
+            artist=self.artist or other.artist,
+            genre=self.genre or other.genre,
+            designer=self.designer or other.designer,
+            difficulty=self.difficulty or other.difficulty,
+            playlevel=self.playlevel or other.playlevel,
+            songid=self.songid or other.songid,
+            wave=self.wave or other.wave,
+            waveoffset=self.waveoffset or other.waveoffset,
+            jacket=self.jacket or other.jacket,
+            background=self.background or other.background,
+            movie=self.movie or other.movie,
+            movieoffset=self.movieoffset or other.movieoffset,
+            basebpm=self.basebpm or other.basebpm,
+        )

--- a/src/pjsekai/scores/notes/__init__.py
+++ b/src/pjsekai/scores/notes/__init__.py
@@ -1,0 +1,6 @@
+from .base import BaseNote
+from .note import Note
+from .tap import Tap, TapType
+from .directional import Directional, DirectionalType
+from .slide import Slide, SlideType
+from .event import Event

--- a/src/pjsekai/scores/notes/base.py
+++ b/src/pjsekai/scores/notes/base.py
@@ -1,0 +1,29 @@
+import dataclasses
+
+from ..types import *
+
+
+@dataclasses.dataclass
+class BaseNote:
+    bar: Fraction
+
+    def __hash__(self) -> int:
+        return hash(str(self))
+
+    def __gt__(self, other: 'BaseNote') -> bool:
+        return self.bar > other.bar
+
+    def __lt__(self, other: 'BaseNote') -> bool:
+        return self.bar < other.bar
+
+    def __ge__(self, other: 'BaseNote') -> bool:
+        return self.bar >= other.bar
+
+    def __le__(self, other: 'BaseNote') -> bool:
+        return self.bar <= other.bar
+
+    def __eq__(self, other: 'BaseNote') -> bool:
+        return self.bar == other.bar
+
+
+bar_event_epsilon = Fraction(1, 10000)

--- a/src/pjsekai/scores/notes/directional.py
+++ b/src/pjsekai/scores/notes/directional.py
@@ -1,0 +1,41 @@
+import enum
+import dataclasses
+
+from .note import Note
+
+
+@dataclasses.dataclass
+class Directional(Note):
+    tap: Note | None = dataclasses.field(default=None, repr=False)
+
+    def __hash__(self) -> int:
+        return hash(str(self))
+
+    def is_critical(self):
+        if self.tap and self.tap.is_critical():
+            return True
+
+        return False
+
+    def is_trend(self):
+        if self.tap and self.tap.is_trend():
+            return True
+
+        return False
+
+    def is_tick(self):
+        if self.is_none():
+            return None
+        if self.is_trend():
+            return False
+
+        return True
+
+
+class DirectionalType(enum.IntEnum):
+    UP = 1
+    DOWN = 2
+    UPPER_LEFT = 3
+    UPPER_RIGHT = 4
+    LOWER_LEFT = 5
+    LOWER_RIGHT = 6

--- a/src/pjsekai/scores/notes/event.py
+++ b/src/pjsekai/scores/notes/event.py
@@ -1,0 +1,37 @@
+import dataclasses
+
+from .base import BaseNote
+from ..types import Fraction
+
+
+@dataclasses.dataclass
+class Event(BaseNote):
+    bpm: Fraction = None
+    bar_length: Fraction = None
+    sentence_length: int = None
+    speed: float = None
+
+    section: str = None
+    text: str = None
+
+    def __post_init__(self):
+        if self.bpm is not None:
+            self.bpm = Fraction(self.bpm)
+
+        if self.bar_length is not None:
+            self.bar_length = Fraction(self.bar_length)
+
+    def __hash__(self) -> int:
+        return hash(str(self))
+
+    def __or__(self, other: 'Event'):
+        assert self.bar <= other.bar
+        return Event(
+            bar=other.bar,
+            bpm=other.bpm or self.bpm,
+            bar_length=other.bar_length or self.bar_length,
+            sentence_length=other.sentence_length or self.sentence_length,
+            speed=other.speed or self.speed,
+            section=other.section or self.section,
+            text=other.text or self.text,
+        )

--- a/src/pjsekai/scores/notes/note.py
+++ b/src/pjsekai/scores/notes/note.py
@@ -1,0 +1,28 @@
+import dataclasses
+
+from .base import BaseNote
+
+
+@dataclasses.dataclass
+class Note(BaseNote):
+    lane: int
+    width: int
+    type: int
+
+    # TODO: speed is not binded to notes in pjsekai
+    speed: float | None = None
+
+    def __hash__(self) -> int:
+        return hash(str(self))
+
+    def is_critical(self):
+        return False
+
+    def is_trend(self):
+        return False
+
+    def is_none(self):
+        return False
+
+    def is_tick(self):
+        return True

--- a/src/pjsekai/scores/notes/slide.py
+++ b/src/pjsekai/scores/notes/slide.py
@@ -1,0 +1,87 @@
+import enum
+import dataclasses
+
+from .note import Note
+
+
+@dataclasses.dataclass
+class Slide(Note):
+    channel: int = 0
+    decoration: bool = False
+
+    tap: Note | None = dataclasses.field(default=None, repr=False)
+    directional: Note | None = dataclasses.field(default=None, repr=False)
+    next: Note | None = dataclasses.field(default=None, repr=False)
+    head: Note | None = dataclasses.field(default=None, repr=False)
+
+    def __hash__(self) -> int:
+        return hash(str(self))
+
+    def is_path(self):
+        if self.type == 0:
+            return False
+
+        if self.type != 3:
+            return True
+
+        if self.directional:
+            return True
+
+        if self.tap is None and self.directional is None:
+            return True
+
+        return False
+
+    def is_critical(self):
+        if self.tap and self.tap.is_critical():
+            return True
+        if self.directional and self.directional.is_critical():
+            return True
+        if self.head is not self and self.head.is_critical():
+            return True
+
+        return False
+
+    def is_trend(self):
+        if self.tap and self.tap.is_trend():
+            return True
+        if self.directional and self.directional.is_trend():
+            return True
+
+        return False
+
+    def is_none(self):
+        if self.tap and self.tap.is_none():
+            return True
+        if self.directional and self.directional.is_none():
+            return True
+
+        return False
+
+    def is_tick(self):
+        if self.is_none():
+            return None
+        if self.decoration:
+            if tap_tick := self.tap and self.tap.is_tick():
+                return tap_tick
+            if directional_tick := self.directional and self.directional.is_tick():
+                return directional_tick
+            if tap_tick is not None or directional_tick is not None:
+                return False
+            return None
+
+        if self.type == SlideType.INVISIBLE:
+            return None
+        if self.is_trend():
+            return False
+        if self.type == SlideType.RELAY:
+            return False
+
+        return True
+
+
+class SlideType(enum.IntEnum):
+    START = 1
+    END = 2
+    RELAY = 3
+    INVISIBLE = 5

--- a/src/pjsekai/scores/notes/tap.py
+++ b/src/pjsekai/scores/notes/tap.py
@@ -1,0 +1,48 @@
+import enum
+import dataclasses
+
+from .note import Note
+
+
+@dataclasses.dataclass
+class Tap(Note):
+
+    def __hash__(self) -> int:
+        return hash(str(self))
+
+    def is_critical(self):
+        if self.type in (TapType.CRITICAL, TapType.CRITICAL_TREND, TapType.CRITICAL_CANCEL):
+            return True
+
+        return False
+
+    def is_trend(self):
+        if self.type in (TapType.TREND, TapType.CRITICAL_TREND):
+            return True
+
+        return False
+
+    def is_none(self):
+        if self.type in (TapType.CANCEL, TapType.CRITICAL_CANCEL):
+            return True
+
+        return False
+
+    def is_tick(self):
+        if self.is_none():
+            return None
+        if self.is_trend():
+            return False
+
+        return True
+
+
+class TapType(enum.IntEnum):
+    TAP = 1
+    CRITICAL = 2
+    FLICK = 3
+    DAMAGE = 4
+    TREND = 5
+    CRITICAL_TREND = 6
+    CANCEL = 7
+    CRITICAL_CANCEL = 8

--- a/src/pjsekai/scores/rebase.py
+++ b/src/pjsekai/scores/rebase.py
@@ -1,0 +1,94 @@
+import json
+import dataclasses
+
+from .notes import *
+from .types import *
+
+from .score import *
+from .meta import *
+
+__all__ = ['Rebase']
+
+
+@dataclasses.dataclass
+class Rebase:
+    offset: float
+    events: list[Event]
+    meta: Meta
+
+    @classmethod
+    def load(cls, a) -> 'Rebase':
+        if isinstance(a, dict):
+            return cls.load_from_dict(a)
+
+        a = json.load(a)
+        return cls.load_from_dict(a)
+
+    @classmethod
+    def load_from_dict(cls, d: dict) -> 'Rebase':
+        return Rebase(
+            offset=d.get('offset', 0),
+            events=[
+                Event(
+                    bar=event.get('bar'),
+                    bpm=event.get('bpm'),
+                    bar_length=event.get('barLength'),
+                    sentence_length=event.get('sentenceLength'),
+                    section=event.get('section'),
+                    text=event.get('text'),
+                )
+                for event in d.get('events', [])
+            ],
+            meta=Meta(**d.get('meta', {})),
+        )
+
+    def __call__(rebase, self: Score) -> Score:
+        score = Score()
+        score.meta = self.meta | rebase.meta
+        score.events = rebase.events
+
+        def rebase_note(note_0: Note):
+            return dataclasses.replace(
+                note_0,
+                bar=score.get_bar_by_time(self.get_time(note_0.bar) - rebase.offset),
+                **{
+                    key: None
+                    for key in {
+                        Tap: [],
+                        Directional: ['tap'],
+                        Slide: ['tap', 'directional', 'next', 'head'],
+                    }[type(note_0)]
+                },
+            )
+
+        for note_0 in self.notes:
+            if isinstance(note_0, Tap):
+                score.notes.append(rebase_note(note_0))
+
+            elif isinstance(note_0, Directional):
+                score.notes.append(rebase_note(note_0))
+                if note_0.tap:
+                    score.notes.append(rebase_note(note_0.tap))
+
+            elif isinstance(note_0, Slide):
+                score.notes.append(rebase_note(note_0))
+                if note_0.tap:
+                    score.notes.append(rebase_note(note_0.tap))
+                if note_0.directional:
+                    score.notes.append(rebase_note(note_0.directional))
+                    if note_0.directional.tap and note_0.directional.tap is not note_0.tap:
+                        score.notes.append(rebase_note(note_0.directional.tap))
+
+        score.events = sorted(score.events + [
+            dataclasses.replace(event, bar=score.get_bar_by_time(self.get_time(event.bar) - rebase.offset))
+            for event in self.events
+            if event.speed or event.text
+        ])
+
+        score.notes.sort(key=lambda note: note.bar)
+        score._init_notes()
+        score._init_events()
+        return score
+
+    def rebase(rebase, self: Score) -> Score:
+        return rebase(self)

--- a/src/pjsekai/scores/score.py
+++ b/src/pjsekai/scores/score.py
@@ -1,0 +1,214 @@
+import bisect
+import functools
+
+from .notes import *
+from .types import *
+
+from .meta import *
+from .line import *
+
+__all__ = ['Score']
+
+
+class Score:
+
+    def __init__(self):
+        self.meta = Meta()
+        self.notes: list[Note] = []
+        self.events: list[Event] = []
+
+    def _init_by_lines(self, lines: list[Line]):
+        self.meta = Meta()
+        self.notes = []
+        self.events = []
+
+        bpm_definitions: dict[int, Fraction] = {}
+        speed_definitions: dict[int, SpeedDefinition] = {}
+        speed_control = SpeedControl(None)
+        ticks_per_beat = TicksPerBeat(480)
+
+        for line in lines:
+            for object in line.parse():
+                match object:
+                    case Meta():
+                        self.meta |= object
+
+                    case TicksPerBeat():
+                        self.ticks_per_beat = object
+
+                    case SpeedControl():
+                        speed_control = object
+
+                    case SpeedDefinition():
+                        speed_definitions[object.id] = object
+                        for item in object.items:
+                            bar = item.bar + Fraction(item.tick, ticks_per_beat * 4)
+                            self.events.append(Event(bar=bar, speed=item.speed))
+
+                    case Event():
+                        self.events.append(object)
+
+                    case BpmDefinition():
+                        bpm_definitions[object.id] = object.bpm
+
+                    case BpmReference():
+                        self.events.append(Event(bar=object.bar, bpm=bpm_definitions[object.id]))
+
+                    case Note():
+                        self.notes.append(object)
+
+        self._init_notes()
+        self._init_events()
+
+    def _init_notes(self):
+        self.notes.sort()
+
+        note_deleted = [False] * len(self.notes)
+        note_indexes: dict[Fraction, list[int]] = {}
+
+        for i, note in enumerate(self.notes):
+            if not 0 <= note.lane - 2 < 12:
+                note_deleted[i] = True
+                self.events.append(Event(
+                    bar=note.bar,
+                    text='SKILL' if note.lane == 0 else 'FEVER CHANCE!' if note.type == 1 else 'SUPER FEVER!!',
+                ))
+                continue
+
+            if note.bar not in note_indexes:
+                note_indexes[note.bar] = []
+
+            note_indexes[note.bar].append(i)
+
+        for i, directional in enumerate(self.notes):
+            if note_deleted[i] or not isinstance(directional, Directional):
+                continue
+
+            for j in note_indexes[directional.bar]:
+                tap = self.notes[j]
+                if note_deleted[j] or not isinstance(tap, Tap):
+                    continue
+
+                if tap.bar == directional.bar and tap.lane == directional.lane and tap.width == directional.width:
+                    note_deleted[j] = True
+                    directional.tap = tap
+
+        for i, slide in enumerate(self.notes):
+            if note_deleted[i] or not isinstance(slide, Slide):
+                continue
+
+            if slide.head is None:
+                slide.head = slide
+
+            for j in note_indexes[slide.bar]:
+                tap = self.notes[j]
+                if note_deleted[j] or not isinstance(tap, Tap):
+                    continue
+
+                if tap.bar == slide.bar and tap.lane == slide.lane and tap.width == slide.width:
+                    note_deleted[j] = True
+                    slide.tap = tap
+
+            for j in note_indexes[slide.bar]:
+                directional = self.notes[j]
+                if note_deleted[j] or not isinstance(directional, Directional):
+                    continue
+
+                if directional.bar == slide.bar and directional.lane == slide.lane and directional.width == slide.width:
+                    note_deleted[j] = True
+                    slide.directional = directional
+                    if directional.tap is not None:
+                        slide.tap = directional.tap
+
+            if slide.type != SlideType.END:
+                for j in range(i+1, len(self.notes)):
+                    next = self.notes[j]
+                    if note_deleted[j] or not isinstance(next, Slide) or next.channel != slide.channel or next.decoration != slide.decoration:
+                        continue
+
+                    slide.next = next
+                    next.head = slide.head
+                    break
+
+        self.notes = [note for i, note in enumerate(self.notes) if not note_deleted[i]]
+
+    def _init_events(self):
+        self.events.sort()
+        events = []
+
+        for event in self.events:
+            if len(events) and event == events[-1]:
+                events[-1] |= event
+            else:
+                events.append(event)
+
+        self.events = events
+
+    @classmethod
+    def open(cls, file: str, *args, **kwargs):
+        self = cls()
+        with open(file, *args, **kwargs) as f:
+            self._init_by_lines([Line(line) for line in f.readlines()])
+
+        return self
+
+    @functools.cached_property
+    def timed_events(self):
+        timed_events: list[tuple[Fraction, Event]] = []
+
+        t = 0
+        e = Event(bar=0, bpm=120, bar_length=4, sentence_length=4)
+        for i, event in enumerate(self.events):
+            t += (event.bar - e.bar) * e.bar_length * 60 / e.bpm
+            e |= event
+
+            timed_events.append((t, e))
+
+        if not timed_events:
+            timed_events.append((0, e))
+
+        return timed_events
+
+    def get_timed_event(self, bar: Fraction) -> tuple[Fraction, Event]:
+        t, e = self.timed_events[bisect.bisect(self.timed_events, bar, key=lambda x: x[1].bar) - 1]
+        t += e.bar_length * 60 / e.bpm * (bar - e.bar)
+        return t, e
+
+    def get_time(self, bar: Fraction) -> Fraction:
+        return self.get_timed_event(bar)[0]
+
+    def get_event(self, bar: Fraction) -> Event:
+        return self.get_timed_event(bar)[1]
+
+    def get_time_delta(self, bar_from: Fraction, bar_to: Fraction) -> Fraction:
+        return self.get_time(bar_to) - self.get_time(bar_from)
+
+    def get_bar_by_time(self, time: float) -> Fraction:
+        t = 0.0
+        event = Event(bar=0, bpm=120, bar_length=4, sentence_length=4)
+
+        for i in range(len(self.events)):
+            event = event | self.events[i]
+            if i+1 == len(self.events):
+                break
+
+            event_time = event.bar_length * 60 / event.bpm * (self.events[i+1].bar - event.bar)
+            if t + event_time > time:
+                break
+            else:
+                t += event_time
+
+        bar = event.bar + (time - t) / (event.bar_length * 60 / event.bpm)
+
+        return Fraction(bar).limit_denominator()
+
+    def print(self, bar_from: int, bar_to: int):
+        for note in self.notes:
+            if bar_from <= note.bar < bar_to:
+                print(note, f'{note.is_trend() = }')
+                if hasattr(note, 'tap') and note.tap:
+                    print('    tap:', note.tap, f'{note.tap.is_trend() = }')
+                if hasattr(note, 'directional') and note.directional:
+                    print('    directional:', note.directional, f'{note.directional.is_trend() = }')
+
+                print()

--- a/src/pjsekai/scores/types/__init__.py
+++ b/src/pjsekai/scores/types/__init__.py
@@ -1,0 +1,1 @@
+from .fraction import Fraction

--- a/src/pjsekai/scores/types/fraction.py
+++ b/src/pjsekai/scores/types/fraction.py
@@ -1,0 +1,51 @@
+import fractions
+import operator
+
+
+class Fraction(fractions.Fraction):
+    def __str__(self) -> str:
+        i = int(self)
+        if i == 0:
+            return fractions.Fraction.__str__(self)
+        if i == self:
+            return f'{i}.'
+
+        return f'{i}.+{fractions.Fraction.__str__(self - i)}'
+
+    def __repr__(self) -> str:
+        return str(self)
+
+    def _wrap_result(f):
+        def g(*args, **kwargs):
+            ans = f(*args, **kwargs)
+            if isinstance(ans, fractions.Fraction):
+                ans = Fraction(ans)
+            return ans
+        return g
+
+    __add__ = _wrap_result(fractions.Fraction.__add__)
+
+    for f in (
+        'limit_denominator',
+        '__add__', '__radd__',
+        '__sub__', '__rsub__',
+        '__mul__', '__rmul__',
+        '__truediv__', '__rtruediv__',
+        '__floordiv__', '__rfloordiv__',
+        '__mod__', '__rmod__',
+        '__pow__', '__rpow__',
+        '__pos__',
+        '__neg__',
+        '__abs__',
+        '__trunc__',
+        '__floor__',
+        '__ceil__',
+        '__round__',
+    ):
+        exec(f'{f} = _wrap_result(fractions.Fraction.{f})')
+
+
+if __name__ == '__main__':
+    a = Fraction(2, 2)
+    a = a + 1
+    print(a, type(a))

--- a/src/plugins/sekai/modules/music.py
+++ b/src/plugins/sekai/modules/music.py
@@ -1193,8 +1193,8 @@ async def get_music_chart_length(ctx: SekaiHandlerContext, music_id: int, diffic
     sus_path = await ctx.rip.get_asset_cache_path(f"music/music_score/{music_id:04d}_01_rip/{difficulty}")
     if not sus_path:
         return None
-    import pjsekai.scores
-    score = pjsekai.scores.Score.open(sus_path, encoding='UTF-8')
+    from src.pjsekai import scores as pjsekai_scores
+    score = pjsekai_scores.Score.open(sus_path, encoding='UTF-8')
     return timedelta(seconds=float(score.timed_events[-1][0]))
 
 # 合成简要歌曲列表图片


### PR DESCRIPTION
将https://github.com/[Sekai-World/pjsekai-scores](https://github.com/Sekai-World/pjsekai-scores)的源代码下载下来，参考https://github.com/xfl03/SekaiMusicChart的代码加以修改，实现谱面预览可以查看技能覆盖情况等功能。

主要修改：
  - 添加了src/pjsekai/scores文件夹，你可以按自己喜好将它放置在其他位置和改名。用其中的代码替代了原本pjsekai.scores库的功能。
  - 修改了src/plugins/sekai/modules/chart.py文件。
      - 添加了两个导入：
            from .deck import musicmetas_json
            from src.pjsekai import scores as pjsekai_scores
      - 为 `谱面查询` 指令添加一个"技能"参数校验，在调用generate_music_chart时添加了skill参数和style_sheet参数。 这里的"white"样式是来自于33的仓库中的，我将它放在附件中，你也可以参考它自己修改样式。
      - 为generate_music_chart函数添加了一个可选参数"skill"，bool型，默认为False。
      - 修改了generate_music_chart函数中的内容。cache_path会带技能和不带技能的；当skill参数为True时，还会获取该歌曲在该difficulty下的meta数据。和skill参数一起传递给pjsekai_scores.Drawing对象。
  - 修改了src/plugins/sekai/modules/music.py中的函数get_music_chart_length的部分内容，不再使用pjsekai.scores库。

[white.css](https://github.com/user-attachments/files/24355351/white.css)
